### PR TITLE
fix issue with loading the tutorial multiple times

### DIFF
--- a/testAI.md
+++ b/testAI.md
@@ -37,5 +37,5 @@ Goals.pollution()
 ```
 
 ```package
-AIBlocks=github:fountainstudios/AICustomBlocks
+aicustomblocks=github:fountainstudios/AICustomBlocks
 ```


### PR DESCRIPTION
When loading the testAI tutorial multiple times, right now our api caching logic is failing due to a name mix up (fixed on our side with https://github.com/microsoft/pxt/pull/7427).

For now, you can work around this by keeping the ids the same as the repo name in lower case when importing extensions, like in this change.

And worth a note, after this fix is live, you will need to make a change in the other repo for it to get past the cache for any devices that it has currently been loaded on (or clear caches on each device). No particular change is required, can just add a comment or something in the code -- any byte changing will cause it to recompile instead of taking the currently broken version that is cached.